### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 aioprocessing (1.0.1-5) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
+  * Set upstream metadata fields: Bug-Submit.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 04:31:39 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+aioprocessing (1.0.1-5) UNRELEASED; urgency=medium
+
+  * Set field Upstream-Contact in debian/copyright.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 04:31:39 +0000
+
 aioprocessing (1.0.1-4) unstable; urgency=medium
 
   * Fix autopkgtest for Python 3.7 (Closes: #912932).

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ aioprocessing (1.0.1-5) UNRELEASED; urgency=medium
 
   * Set field Upstream-Contact in debian/copyright.
   * Set upstream metadata fields: Bug-Submit.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata
+    (already present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 04:31:39 +0000
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: aioprocessing
 Source: https://github.com/dano/aioprocessing
+Upstream-Contact: Dan O'Reilly <<oreilldf@gmail.com>>
 
 Files: *
 Copyright: 2014 Dan O'Reilly <oreilldf@gmail.com>

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -2,9 +2,7 @@ Archive: GitHub
 Bug-Database: https://github.com/dano/aioprocessing/issues
 Bug-Submit: https://github.com/dano/aioprocessing/issues/new
 Bus-Submit: https://github.com/dano/aioprocessing/issues/new 
-Contact: Dan O'Reilly <<oreilldf@gmail.com>>
 Documentation: https://github.com/dano/aioprocessing/blob/master/README.md
-Name: aioprocessing
 Repository: https://github.com/dano/aioprocessing.git
 Repository-Browse: https://github.com/dano/aioprocessing
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,5 +1,6 @@
 Archive: GitHub
 Bug-Database: https://github.com/dano/aioprocessing/issues
+Bug-Submit: https://github.com/dano/aioprocessing/issues/new
 Bus-Submit: https://github.com/dano/aioprocessing/issues/new 
 Contact: Dan O'Reilly <<oreilldf@gmail.com>>
 Documentation: https://github.com/dano/aioprocessing/blob/master/README.md


### PR DESCRIPTION
Fix some issues reported by lintian
* Set field Upstream-Contact in debian/copyright.
* Set upstream metadata fields: Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/aioprocessing/662e0182-3ddc-402a-bbdb-ecb3cf3597c3.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/662e0182-3ddc-402a-bbdb-ecb3cf3597c3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/662e0182-3ddc-402a-bbdb-ecb3cf3597c3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/662e0182-3ddc-402a-bbdb-ecb3cf3597c3/diffoscope)).
